### PR TITLE
fix: remove rogue "on_trash" hook "method"

### DIFF
--- a/taxjar_integration/hooks.py
+++ b/taxjar_integration/hooks.py
@@ -105,8 +105,7 @@ app_license = "MIT"
 doc_events = {
 	"Sales Invoice": {
 		"on_submit": "taxjar_integration.taxjar_integration.taxjar_integration.create_transaction",
-		"on_cancel": "taxjar_integration.taxjar_integration.taxjar_integration.delete_transaction",
-		"on_trash": "method"
+		"on_cancel": "taxjar_integration.taxjar_integration.taxjar_integration.delete_transaction"
 	},
 	("Quotation", "Sales Order", "Sales Invoice"): {
 		"validate": ["taxjar_integration.taxjar_integration.taxjar_integration.set_sales_tax"]


### PR DESCRIPTION
AFAIK, "method" means nothing meaningful in this context, and simply induces errors when trying to delete sales invoices.